### PR TITLE
Added Miri checks to CI

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -17,3 +17,18 @@ jobs:
         id: make_test
         run: |
           make test
+
+  miri-checks:
+    name: Miri
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install Rust
+        run: |
+          rustup toolchain install nightly-2021-01-19
+          rustup default nightly-2021-01-19
+          rustup component add rustfmt miri
+      - name: Run
+        run: |
+          make miri

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 test:
 	cargo test -- --nocapture
 
+miri:
+	cargo miri test -- --nocapture
+
 bench:
 	cargo bench -- --nocapture
 
@@ -14,4 +17,4 @@ build:
 clean:
 	cargo clean
 
-.PHONY: test bench lint build clean
+.PHONY: test bench lint build clean miri


### PR DESCRIPTION
This PR adds [Miri](https://github.com/rust-lang/miri) checks to the CI, which helps at validating that the crate's usage of `unsafe` is sound.

This came up as a concern (of mine) on https://github.com/apache/arrow/pull/9602, so I am just addressing it here.

Note that there may be some actions to reduce some of the code.

Great work on this crate, btw. :)