### PR TITLE
Avoid an unpredictable branch in adjust_heap

### DIFF
--- a/benches/sort.rs
+++ b/benches/sort.rs
@@ -4,7 +4,7 @@ extern crate rand;
 
 use std::collections::BinaryHeap;
 
-use criterion::{BatchSize, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use partial_sort::PartialSort;
 use rand::distributions::{Distribution, Standard};
 use rand::rngs::StdRng;

--- a/benches/sort.rs
+++ b/benches/sort.rs
@@ -25,7 +25,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter_batched_ref(
             || create_vec::<u64>(n),
             |v| v.partial_sort(20, |a, b| a.cmp(b)),
-            BatchSize::SmallInput
+            BatchSize::SmallInput,
         )
     });
 
@@ -33,7 +33,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter_batched_ref(
             || create_vec::<u64>(n),
             |v| v.partial_sort(200, |a, b| a.cmp(b)),
-            BatchSize::SmallInput
+            BatchSize::SmallInput,
         )
     });
 
@@ -41,7 +41,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter_batched_ref(
             || create_vec::<u64>(n),
             |v| v.partial_sort(2000, |a, b| a.cmp(b)),
-            BatchSize::SmallInput
+            BatchSize::SmallInput,
         )
     });
 
@@ -49,7 +49,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter_batched_ref(
             || create_vec::<u64>(n),
             |v| v.partial_sort(10000, |a, b| a.cmp(b)),
-            BatchSize::SmallInput
+            BatchSize::SmallInput,
         )
     });
 
@@ -57,7 +57,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter_batched_ref(
             || create_vec::<u64>(n),
             |v| v.sort_by(|a, b| a.cmp(b)),
-            BatchSize::SmallInput
+            BatchSize::SmallInput,
         )
     });
 
@@ -65,7 +65,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter_batched(
             || create_vec::<u64>(n),
             |v| BinaryHeap::from(v).into_sorted_vec(),
-            BatchSize::SmallInput
+            BatchSize::SmallInput,
         )
     });
 
@@ -73,7 +73,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter_batched_ref(
             || create_vec::<u64>(n),
             |v| v.partial_sort(20, |a, b| a.cmp(b).reverse()),
-            BatchSize::SmallInput
+            BatchSize::SmallInput,
         )
     });
 
@@ -81,7 +81,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter_batched_ref(
             || create_vec::<u64>(n),
             |v| v.sort_by(|a, b| a.cmp(b).reverse()),
-            BatchSize::SmallInput
+            BatchSize::SmallInput,
         )
     });
 }

--- a/benches/sort.rs
+++ b/benches/sort.rs
@@ -4,7 +4,7 @@ extern crate rand;
 
 use std::collections::BinaryHeap;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{BatchSize, criterion_group, criterion_main, Criterion};
 use partial_sort::PartialSort;
 use rand::distributions::{Distribution, Standard};
 use rand::rngs::StdRng;
@@ -21,68 +21,68 @@ where
 fn criterion_benchmark(c: &mut Criterion) {
     let n = 10000;
 
-    let mut v = create_vec::<u64>(n);
-    let mut vv = v.clone();
-    vv.sort();
-
-    v.partial_sort(2000, |a, b| a.cmp(b));
-    assert_eq!(&vv[0..2000], &v[0..2000]);
-
-    let mut v = create_vec::<u64>(n);
     c.bench_function("partial sort 10000 limit 20", |b| {
-        b.iter(|| {
-            v.partial_sort(20, |a, b| a.cmp(b));
-        })
+        b.iter_batched_ref(
+            || create_vec::<u64>(n),
+            |v| v.partial_sort(20, |a, b| a.cmp(b)),
+            BatchSize::SmallInput
+        )
     });
 
-    let mut v = create_vec::<u64>(n);
     c.bench_function("partial sort 10000 limit 200", |b| {
-        b.iter(|| {
-            v.partial_sort(200, |a, b| a.cmp(b));
-        })
+        b.iter_batched_ref(
+            || create_vec::<u64>(n),
+            |v| v.partial_sort(200, |a, b| a.cmp(b)),
+            BatchSize::SmallInput
+        )
     });
 
-    let mut v = create_vec::<u64>(n);
     c.bench_function("partial sort 10000 limit 2000", |b| {
-        b.iter(|| {
-            v.partial_sort(2000, |a, b| a.cmp(b));
-        })
+        b.iter_batched_ref(
+            || create_vec::<u64>(n),
+            |v| v.partial_sort(2000, |a, b| a.cmp(b)),
+            BatchSize::SmallInput
+        )
     });
 
-    let mut v = create_vec::<u64>(n);
     c.bench_function("partial sort 10000 limit 10000", |b| {
-        b.iter(|| {
-            v.partial_sort(10000, |a, b| a.cmp(b));
-        })
+        b.iter_batched_ref(
+            || create_vec::<u64>(n),
+            |v| v.partial_sort(10000, |a, b| a.cmp(b)),
+            BatchSize::SmallInput
+        )
     });
 
-    let mut v = create_vec::<u64>(n);
     c.bench_function("stdsort 10000", |b| {
-        b.iter(|| {
-            v.sort_by(|a, b| a.cmp(b));
-        })
+        b.iter_batched_ref(
+            || create_vec::<u64>(n),
+            |v| v.sort_by(|a, b| a.cmp(b)),
+            BatchSize::SmallInput
+        )
     });
 
     c.bench_function("heapsort 10000", |b| {
-        b.iter(|| {
-            let v = create_vec::<u64>(n);
-            let h = BinaryHeap::from(v);
-            h.into_sorted_vec();
-        })
+        b.iter_batched(
+            || create_vec::<u64>(n),
+            |v| BinaryHeap::from(v).into_sorted_vec(),
+            BatchSize::SmallInput
+        )
     });
 
-    let mut v = create_vec::<u64>(n);
     c.bench_function("partial reverse sort 10000 limit 20", |b| {
-        b.iter(|| {
-            v.partial_sort(20, |a, b| a.cmp(b).reverse());
-        })
+        b.iter_batched_ref(
+            || create_vec::<u64>(n),
+            |v| v.partial_sort(20, |a, b| a.cmp(b).reverse()),
+            BatchSize::SmallInput
+        )
     });
 
-    let mut v = create_vec::<u64>(n);
     c.bench_function("stdsort reverse 10000", |b| {
-        b.iter(|| {
-            v.sort_by(|a, b| a.cmp(b).reverse());
-        })
+        b.iter_batched_ref(
+            || create_vec::<u64>(n),
+            |v| v.sort_by(|a, b| a.cmp(b).reverse()),
+            BatchSize::SmallInput
+        )
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,10 @@ where
             // SAFETY:
             // we ensure left_child and left_child + 1 are between [0, len)
             if left_child + 1 < len {
-                left_child += usize::from(is_less(v.get_unchecked(left_child), v.get_unchecked(left_child + 1)));
+                left_child += usize::from(is_less(
+                    v.get_unchecked(left_child),
+                    v.get_unchecked(left_child + 1),
+                ));
             }
 
             // SAFETY:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,10 +120,8 @@ where
         while left_child < len {
             // SAFETY:
             // we ensure left_child and left_child + 1 are between [0, len)
-            if left_child + 1 < len
-                && is_less(v.get_unchecked(left_child), v.get_unchecked(left_child + 1))
-            {
-                left_child += 1;
+            if left_child + 1 < len {
+                left_child += usize::from(is_less(v.get_unchecked(left_child), v.get_unchecked(left_child + 1)));
             }
 
             // SAFETY:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,7 @@ mod tests {
 
         before.partial_sort(last, |a, b| cmp_model(a.1.as_ref(), b.1.as_ref()));
 
-        &d[0..last].iter().zip(&before[0..last]).map(|(a, b)| {
+        d[0..last].iter().zip(&before[0..last]).for_each(|(a, b)| {
             assert_eq!(a.0, b.0);
             assert_eq!(a.1.size(), b.1.size());
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,15 +159,14 @@ where
 }
 
 #[inline]
-fn sort_heap<T, F>(v: &mut [T], last: usize, is_less: &mut F)
+fn sort_heap<T, F>(v: &mut [T], mut last: usize, is_less: &mut F)
 where
     F: FnMut(&T, &T) -> bool,
 {
-    let mut last = last;
     while last > 1 {
-        v.swap(0, last - 1);
-        adjust_heap(v, 0, last - 1, is_less);
         last -= 1;
+        v.swap(0, last);
+        adjust_heap(v, 0, last, is_less);
     }
 }
 


### PR DESCRIPTION
Best reviewed in individual commits: First made benchmarks compile warning-free. Then tweaked benchmark suite to avoid running all but the first iteration on pre-sorted vectors. This is the baseline of the benchmark below.

Then applied the trick from rust-lang/rust#107894.

```
partial sort 10000 limit 20
                        time:   [8.0188 µs 8.1554 µs 8.2674 µs]
                        change: [-2.7494% -0.1324% +2.7230%] (p = 0.92 > 0.05)
                        No change in performance detected.

partial sort 10000 limit 200
                        time:   [26.747 µs 26.829 µs 26.906 µs]
                        change: [-33.211% -32.714% -32.271%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

partial sort 10000 limit 2000
                        time:   [198.98 µs 199.20 µs 199.44 µs]
                        change: [-42.777% -42.615% -42.444%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe

partial sort 10000 limit 10000
                        time:   [433.62 µs 433.94 µs 434.28 µs]
                        change: [-44.248% -43.919% -43.479%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

stdsort 10000           time:   [467.99 µs 468.56 µs 469.32 µs]
                        change: [-0.3978% -0.0901% +0.2158%] (p = 0.58 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe

heapsort 10000          time:   [386.09 µs 387.61 µs 389.65 µs]
                        change: [+0.1621% +0.6070% +1.0347%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

partial reverse sort 10000 limit 20
                        time:   [8.3382 µs 8.4630 µs 8.5677 µs]
                        change: [+0.5061% +3.1246% +5.8963%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

stdsort reverse 10000   time:   [497.47 µs 497.73 µs 497.99 µs]
                        change: [-0.7798% -0.1396% +0.4953%] (p = 0.70 > 0.05)
                        No change in performance detected.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  7 (7.00%) high severe
```