### PR TITLE
Improve safety commentary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,9 @@ fn adjust_heap<T, F>(v: &mut [T], hole_index: usize, len: usize, is_less: &mut F
 where
     F: FnMut(&T, &T) -> bool,
 {
+    assert!(len <= v.len());
+    assert!(hole_index < v.len());
+
     let mut left_child = hole_index * 2 + 1;
 
     //SAFETY: we ensure hole_index point to a properly initialized value of type T

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,10 +101,10 @@ where
 
     let mut left_child = hole_index * 2 + 1;
 
-    //SAFETY: we ensure hole_index point to a properly initialized value of type T
-    let mut tmp = unsafe { mem::ManuallyDrop::new(ptr::read(&v[hole_index])) };
+    // SAFETY: we ensure hole_index point to a properly initialized value of type T
+    let tmp = mem::ManuallyDrop::new(unsafe { ptr::read(&v[hole_index]) });
     let mut hole = InsertionHole {
-        src: &mut *tmp,
+        src: &*tmp,
         dest: &mut v[hole_index],
     };
     // Panic safety:
@@ -146,7 +146,7 @@ where
     // These codes is from std::sort_by
     // When dropped, copies from `src` into `dest`.
     struct InsertionHole<T> {
-        src: *mut T,
+        src: *const T,
         dest: *mut T,
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,50 +101,48 @@ where
 
     let mut left_child = hole_index * 2 + 1;
 
-    // SAFETY: we ensure hole_index point to a properly initialized value of type T
+    // SAFETY: Reading from a reference is always valid. The original memory
+    // location is now conceptually moved-from. At the end of the function,
+    // or if `is_less()` panics at any point, `hole` is dropped and fills
+    // the moved-from location with a valid element.
     let tmp = mem::ManuallyDrop::new(unsafe { ptr::read(&v[hole_index]) });
     let mut hole = InsertionHole {
         src: &*tmp,
         dest: &mut v[hole_index],
     };
-    // Panic safety:
-    //
-    // If `is_less` panics at any point during the process, `hole` will get dropped and fill the
-    // hole in `v` with the unconsumed range in `buf`, thus ensuring that `v` still holds every
-    // object it initially held exactly once.
 
-    // SAFETY:
-    // we ensure src/dest point to a properly initialized value of type T
-    // src is valid for reads of `count * size_of::<T>()` bytes.
-    // dest is valid for reads of `count * size_of::<T>()` bytes.
-    // Both `src` and `dst` are properly aligned.
-
-    unsafe {
-        while left_child < len {
-            // SAFETY:
-            // we ensure left_child and left_child + 1 are between [0, len)
-            if left_child + 1 < len {
-                left_child += usize::from(is_less(
-                    v.get_unchecked(left_child),
-                    v.get_unchecked(left_child + 1),
-                ));
-            }
-
-            // SAFETY:
-            // left_child and hole.dest point to a properly initialized value of type T
-            if is_less(&*tmp, v.get_unchecked(left_child)) {
-                ptr::copy_nonoverlapping(&v[left_child], hole.dest, 1);
-                hole.dest = &mut v[left_child];
-            } else {
-                break;
-            }
-
-            left_child = left_child * 2 + 1;
+    while left_child < len {
+        if left_child + 1 < len {
+            left_child += usize::from(is_less(
+                unsafe { v.get_unchecked(left_child) }, // SAFETY: left_child < len
+                unsafe { v.get_unchecked(left_child + 1) }, // SAFETY: left_child + 1 < len
+            ));
         }
+
+        // SAFETY: left_child (even incremented) is still in bounds.
+        if !is_less(&*tmp, unsafe { v.get_unchecked(left_child) }) {
+            break;
+        }
+
+        // SAFETY: Source and destination are references. Now the location
+        // at index left_child is conceptually moved-from and `hole` is updated
+        // accordingly. At the end of the function, or if `is_less()` panics
+        // at any point, `hole` is dropped and fills the moved-from location
+        // with a valid element.
+        unsafe {
+            ptr::copy_nonoverlapping(
+                v.get_unchecked(left_child), // SAFETY: still in bounds
+                hole.dest,
+                1,
+            );
+        }
+        hole.dest = &mut v[left_child];
+
+        left_child = left_child * 2 + 1;
     }
 
-    // These codes is from std::sort_by
-    // When dropped, copies from `src` into `dest`.
+    // When dropped, copies from `src` into `dest`. Adapted from
+    // `std::sort_by()`.
     struct InsertionHole<T> {
         src: *const T,
         dest: *mut T,
@@ -152,11 +150,8 @@ where
 
     impl<T> Drop for InsertionHole<T> {
         fn drop(&mut self) {
-            // SAFETY:
-            // we ensure src/dest point to a properly initialized value of type T
-            // src is valid for reads of `count * size_of::<T>()` bytes.
-            // dest is valid for reads of `count * size_of::<T>()` bytes.
-            // Both `src` and `dst` are properly aligned.
+            // SAFETY: `self.src` and `self.dest` have been created from
+            // references.
             unsafe {
                 ptr::copy_nonoverlapping(self.src, self.dest, 1);
             }


### PR DESCRIPTION
No functional changes.

Some safety arguments were still referring to requirements of `std::sort_by()`. Tried to update and simplify them.

Also asserted all required invariants again at the start of `adjust_heap()`, fully encapsulating any unsafety. This does not cost anything. In fact, it even improves code generation, for minor perf win.

Finally, use one more `get_unchecked()`, for another small perf win.

```
partial sort 10000 limit 20                                                                            
                        time:   [11.151 µs 11.310 µs 11.445 µs]
                        change: [-8.3759% -5.8887% -3.1070%] (p = 0.00 < 0.05)
                        Performance has improved.

partial sort 10000 limit 200                                                                            
                        time:   [26.731 µs 26.923 µs 27.093 µs]
                        change: [-17.203% -16.355% -15.488%] (p = 0.00 < 0.05)
                        Performance has improved.

partial sort 10000 limit 2000                                                                            
                        time:   [216.37 µs 216.62 µs 216.88 µs]
                        change: [-1.2006% -0.9792% -0.7786%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe

partial sort 10000 limit 10000                                                                            
                        time:   [470.12 µs 470.57 µs 471.06 µs]
                        change: [+1.4179% +1.6662% +1.9709%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

stdsort 10000           time:   [538.39 µs 539.27 µs 540.19 µs]                          
                        change: [-0.0053% +0.2035% +0.4107%] (p = 0.05 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild

unstable stdsort 10000  time:   [337.08 µs 337.55 µs 338.11 µs]                                   
                        change: [-0.1729% +0.1181% +0.5029%] (p = 0.53 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

heapsort 10000          time:   [414.32 µs 414.76 µs 415.22 µs]                           
                        change: [-0.6792% -0.3267% -0.0496%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

partial reverse sort 10000 limit 20                                                                            
                        time:   [10.308 µs 10.566 µs 10.788 µs]
                        change: [-7.4509% -2.5490% +2.5338%] (p = 0.32 > 0.05)
                        No change in performance detected.

stdsort reverse 10000   time:   [584.41 µs 584.95 µs 585.49 µs]                                  
                        change: [+0.0255% +0.1630% +0.2948%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high mild
```