### PR TITLE
Fix partial_sort(_, k) is comparable to select_nth_unstable(_, k - 1)

### DIFF
--- a/benches/sort.rs
+++ b/benches/sort.rs
@@ -25,7 +25,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         b.iter_batched_ref(
             || create_vec::<u64>(n),
             |v| {
-                let (p, _, _) = v.select_nth_unstable(20);
+                let (p, _, _) = v.select_nth_unstable(20 - 1);
                 p.sort_unstable();
             },
             BatchSize::SmallInput,


### PR DESCRIPTION
Because afterwards 20 elements are in the correct position. Does not significantly change the benchmark results.